### PR TITLE
➕ Add @jovotech/cli dependency

### DIFF
--- a/jovo.project.js
+++ b/jovo.project.js
@@ -1,4 +1,4 @@
-const { ProjectConfig } = require('@jovotech/cli-core');
+const { ProjectConfig } = require('@jovotech/cli');
 
 /*
   |--------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@babel/preset-env": "^7.14.7",
     "@babel/register": "^7.14.5",
     "@babel/runtime": "^7.14.6",
-    "@jovotech/cli-core": "^4.0.0",
+    "@jovotech/cli": "^4.0.0",
     "babel-jest": "^27.0.6",
     "bestzip": "^2.2.0",
     "esbuild": "^0.13.13",


### PR DESCRIPTION
This PR adds `@jovotech/cli` as a dependency, instead of `@jovotech/cli-core`, in correspondence with jovotech/jovo-cli/pull/276